### PR TITLE
documentation for use with HTTP an GSheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,23 @@ el 1 de Febrero del 2016.
 
 Incluyen 31 departamentos y 1124 municipios / pueblos / ciudades.
 
-## Utilización JavaScript
+## Uso en JavaScript
 
 Método gracias a Rich en Rich's Blog:
 
 loadJSON es una función que permite extraer por medio de XMLHttpRequest nuestro archivo json.
 
-``` js
-function loadJSON(callback) {   
-
-    var xobj = new XMLHttpRequest();
-        xobj.overrideMimeType("application/json");
-        xobj.open('GET', 'colombia-json.json', true); // Reemplaza colombia-json.json con el nombre que le hayas puesto
-        xobj.onreadystatechange = function () {
-          if (xobj.readyState == 4 && xobj.status == "200") {
-            callback(xobj.responseText);
-          }
-    };
-    xobj.send(null);  
+```js
+function loadJSON(callback) {
+	var xobj = new XMLHttpRequest();
+	xobj.overrideMimeType("application/json");
+	xobj.open("GET", "colombia-json.json", true); // Reemplaza colombia-json.json con el nombre que le hayas puesto
+	xobj.onreadystatechange = function () {
+		if (xobj.readyState == 4 && xobj.status == "200") {
+			callback(xobj.responseText);
+		}
+	};
+	xobj.send(null);
 }
 ```
 
@@ -32,10 +31,31 @@ Através de la función anónima, cargamos el JSON de la siguiente forma:
 
 ```js
 function init() {
- loadJSON(function(response) {
-  // Parse JSON string into object
-    var JSONFinal = JSON.parse(response);
- });
+	loadJSON(function (response) {
+		// Parse JSON string into object
+		var JSONFinal = JSON.parse(response);
+	});
 }
 ```
+
 La variable JSONFinal contiene todos nuestros departamentos y ciudades.
+
+## Uso con petición _HTTP_
+
+Puede cargar el JSON mediante una solicitud Http de tipo _GET_ directamente sobre el repositorio, para esto use:
+
+```
+https://raw.githubusercontent.com/marcovega/colombia-json/master/colombia.min.json
+```
+
+### Uso en Google Sheets con petición _HTTP_
+
+Puede usar los datos en Google Sheets importando la librería [ImportJSON](https://github.com/bradjasper/ImportJSON) en las funciones personalizadas de su Hoja de Calculo:
+
+Luego solamente necesita llamar la función mediante:
+
+```
+=ImportJSON("https://raw.githubusercontent.com/marcovega/colombia-json/master/colombia.min.json")
+```
+
+![UsoEnGoogleSheets](https://media.giphy.com/media/ag4sEdGg307UJREHDH/giphy.gif)


### PR DESCRIPTION
He añadido una mejor manera de utilizar el repositorio, sin embargo considero que es mejor generar un JSON con un formato que provenga directamente desde www.datos.gov.co.

Sin embargo queda abierta la posibilidad de desarrollar una extensión de GSheets para incluir estos datos en una hoja de calculo mas rapidamente.

Estaba realizando este [proyecto por aparte](https://gist.github.com/Macorreag/8ad73bc3539f1d730dea484e993e0367), pero murio debido a que Datos.gov.co cancelo el Dataset correspondiente. Considero que esta replica es un buen punto para dejar la documentación correspondiente.

